### PR TITLE
兼容py3，修正语法错误，加载libcrypto模块失败时显示详细错误。

### DIFF
--- a/db_transfer.py
+++ b/db_transfer.py
@@ -79,7 +79,7 @@ class DbTransfer(object):
 		try:
 			import switchrule
 			keys = switchrule.getKeys()
-		except Exception, e:
+		except Exception as e:
 			keys = ['port', 'u', 'd', 'transfer_enable', 'passwd', 'enable' ]
 		conn = cymysql.connect(host=Config.MYSQL_HOST, port=Config.MYSQL_PORT, user=Config.MYSQL_USER,
 								passwd=Config.MYSQL_PASS, db=Config.MYSQL_DB, charset='utf8')
@@ -102,13 +102,13 @@ class DbTransfer(object):
 		#需要动态载入switchrule，以便实时修改规则
 		try:
 			import switchrule
-		except Exception, e:
+		except Exception as e:
 			logging.error('load switchrule.py fail')
 		cur_servers = {}
 		for row in rows:
 			try:
 				allow = switchrule.isTurnOn(row) and row['enable'] == 1 and row['u'] + row['d'] < row['transfer_enable']
-			except Exception, e:
+			except Exception as e:
 				allow = False
 
 			port = row['port']

--- a/server_pool.py
+++ b/server_pool.py
@@ -120,7 +120,7 @@ class ServerPool(object):
 
 					if a_config['server_ipv6'] == "::":
 						ipv6_ok = True
-				except Exception, e:
+				except Exception as e:
 					logging.warn("IPV6 %s " % (e,))
 
 		if 'server' in self.config:
@@ -142,7 +142,7 @@ class ServerPool(object):
 					udp_server.add_to_loop(self.loop)
 					self.udp_servers_pool.update({port: udp_server})
 
-				except Exception, e:
+				except Exception as e:
 					if not ipv6_ok:
 						logging.warn("IPV4 %s " % (e,))
 
@@ -155,7 +155,7 @@ class ServerPool(object):
 			udpsock = socket(AF_INET, SOCK_DGRAM)
 			udpsock.sendto('%s:%s:0:0' % (Config.MANAGE_PASS, port), (Config.MANAGE_BIND_IP, Config.MANAGE_PORT))
 			udpsock.close()
-		except Exception, e:
+		except Exception as e:
 			logging.warn(e)
 		return True
 
@@ -169,12 +169,12 @@ class ServerPool(object):
 			try:
 				self.tcp_servers_pool[port].close(False)
 				del self.tcp_servers_pool[port]
-			except Exception, e:
+			except Exception as e:
 				logging.warn(e)
 			try:
 				self.udp_servers_pool[port].close(False)
 				del self.udp_servers_pool[port]
-			except Exception, e:
+			except Exception as e:
 				logging.warn(e)
 
 		if 'server_ipv6' in self.config:
@@ -185,12 +185,12 @@ class ServerPool(object):
 				try:
 					self.tcp_ipv6_servers_pool[port].close(False)
 					del self.tcp_ipv6_servers_pool[port]
-				except Exception, e:
+				except Exception as e:
 					logging.warn(e)
 				try:
 					self.udp_ipv6_servers_pool[port].close(False)
 					del self.udp_ipv6_servers_pool[port]
-				except Exception, e:
+				except Exception as e:
 					logging.warn(e)
 
 			return True

--- a/shadowsocks/crypto/util.py
+++ b/shadowsocks/crypto/util.py
@@ -88,7 +88,7 @@ def find_library(possible_lib_names, search_symbol, library_name):
                 logging.warn('can\'t find symbol %s in %s', search_symbol,
                              path)
         except ValueError as e:
-            print(e)
+            logging.error(e)
     return None
 
 

--- a/shadowsocks/crypto/util.py
+++ b/shadowsocks/crypto/util.py
@@ -87,8 +87,8 @@ def find_library(possible_lib_names, search_symbol, library_name):
             else:
                 logging.warn('can\'t find symbol %s in %s', search_symbol,
                              path)
-        except Exception:
-            pass
+        except ValueError as e:
+            print(e)
     return None
 
 

--- a/shadowsocks/tcprelay.py
+++ b/shadowsocks/tcprelay.py
@@ -707,8 +707,8 @@ class TCPRelay(object):
         self._closed = False
         self._eventloop = None
         self._fd_to_handlers = {}
-        self.server_transfer_ul = 0L
-        self.server_transfer_dl = 0L
+        self.server_transfer_ul = 0
+        self.server_transfer_dl = 0
 
         self._timeout = config['timeout']
         self._timeouts = []  # a list for all the handlers

--- a/shadowsocks/udprelay.py
+++ b/shadowsocks/udprelay.py
@@ -873,8 +873,8 @@ class UDPRelay(object):
         self._dns_cache = lru_cache.LRUCache(timeout=300)
         self._eventloop = None
         self._closed = False
-        self.server_transfer_ul = 0L
-        self.server_transfer_dl = 0L
+        self.server_transfer_ul = 0
+        self.server_transfer_dl = 0
 
         self._sockets = set()
         self._fd_to_handlers = {}


### PR DESCRIPTION
* 修改了tcprelay.py和udprelay.py。因为原版ss是兼容py3的，所以修改了一下让它继续兼容py3。
* 修正语法错误：` except Exception, e: ` 是旧版本的语法，py2.6之后的版本已不再使用此语法。
* 修改util.py，加载libcrypto模块失败时显示详细错误。

以上修改在我的vps上测试没问题。