### PR TITLE
优化细节。

### DIFF
--- a/shadowsocks/crypto/util.py
+++ b/shadowsocks/crypto/util.py
@@ -87,8 +87,9 @@ def find_library(possible_lib_names, search_symbol, library_name):
             else:
                 logging.warn('can\'t find symbol %s in %s', search_symbol,
                              path)
-        except ValueError as e:
-            logging.error(e)
+        except Exception:
+            if path == paths[-1]:
+                raise
     return None
 
 


### PR DESCRIPTION
修复：搜索完所有路径之后再判断是否抛出错误，而不是遇到错误就抛出。主要是考虑到系统中同时存在32位和64位dll的情况，原来的代码如果第一个找到的dll文件跟系统不符的话会直接报错。