### PR TITLE
add shadowsocks.obfsplugin to setup.py for distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author='clowwindy',
     author_email='clowwindy42@gmail.com',
     url='https://github.com/shadowsocks/shadowsocks',
-    packages=['shadowsocks', 'shadowsocks.crypto'],
+    packages=['shadowsocks', 'shadowsocks.crypto', 'shadowsocks.obfsplugin'],
     package_data={
         'shadowsocks': ['README.rst', 'LICENSE']
     },


### PR DESCRIPTION
修正安装后运行sslocal命令出现：ImportError: No module named 'shadowsocks.obfsplugin'  错误的问题。