### PR TITLE
Support redirect rule

### DIFF
--- a/shadowsocks/common.py
+++ b/shadowsocks/common.py
@@ -22,6 +22,7 @@ import socket
 import struct
 import logging
 import binascii
+import re
 
 def compat_ord(s):
     if type(s) == int:
@@ -115,6 +116,13 @@ def is_ip(address):
             return family
         except (TypeError, ValueError, OSError, IOError):
             pass
+    return False
+
+
+def match_regex(regex, text):
+    regex = re.compile(regex)
+    for item in regex.findall(text):
+        return True
     return False
 
 


### PR DESCRIPTION
Syntax:

match_hostname_regex:port(* means match all port)#redirect_dist_host:redirect_port

and in the config.json(user-config.json) redirect param should be a list,

For example:
```

"redirect": ["*:8080#zhaoj.in:80","zhaojin97.cn:80#127.0.0.1:80","*#pku.edu.cn:80"]

```

This example means abnormal connection which connect to port 8080 will be redirected to zhaoj.in:80,and if there a http request with hostname zhaojin97.cn(you can set hosts file to test it) will be redirected to 127.0.0.1:80,and the rest of abnormal connection will be redirect to pku.edu.cn:80